### PR TITLE
Migrate to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ufbx"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 authors = ["Artur <arturmisiurev@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -10,17 +10,18 @@ keywords = ["bevy", "fbx", "asset", "loader"]
 categories = ["game-development", "graphics"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_asset",
     "bevy_render",
     "bevy_pbr",
     "bevy_scene",
+    "bevy_world_serialization",
 ]}
 ufbx = "0.9"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = true }
+bevy = { version = "0.19", default-features = true }
 serde_json = "1.0.145"
 ufbx = "0.9"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ FBX asset loader for [Bevy](https://bevyengine.org) powered by [ufbx](https://gi
 
 | bevy | bevy_ufbx |
 |------|-----------|
+| 0.19 | 0.19      |
 | 0.18 | 0.18      |
 | 0.17 | 0.17      |
 
@@ -13,14 +14,15 @@ FBX asset loader for [Bevy](https://bevyengine.org) powered by [ufbx](https://gi
 
 ```toml
 [dependencies]
-bevy     = "0.18"
-bevy_ufbx = "0.18"
+bevy     = "0.19"
+bevy_ufbx = "0.19"
 ```
 
 ## Quick start
 
 ```rust
 use bevy::prelude::*;
+use bevy::world_serialization::WorldAssetRoot;
 use bevy_ufbx::FbxPlugin;
 
 fn main() {
@@ -33,7 +35,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera3d::default());
-    commands.spawn(SceneRoot(
+    commands.spawn(WorldAssetRoot(
         asset_server.load("character.fbx#Scene0"),
     ));
 }
@@ -72,7 +74,7 @@ Individual sub-assets can be addressed with `#Label` path suffixes:
 
 | Label             | Type                | Description                             |
 |-------------------|---------------------|-----------------------------------------|
-| `Scene{N}`        | `Scene`             | Scene hierarchy (N = scene index)       |
+| `Scene{N}`        | `WorldAsset`        | Scene hierarchy (N = scene index)       |
 | `Mesh{N}`         | `Mesh`              | Triangulated mesh                       |
 | `Material{N}`     | `StandardMaterial`  | PBR material                            |
 | `Node{N}`         | `FbxNode`           | Transform node                          |
@@ -80,7 +82,7 @@ Individual sub-assets can be addressed with `#Label` path suffixes:
 | `DefaultMaterial` | `StandardMaterial`  | Fallback material when none is present  |
 
 ```rust
-let scene    = asset_server.load::<Scene>("model.fbx#Scene0");
+let scene    = asset_server.load::<WorldAsset>("model.fbx#Scene0");
 let mesh     = asset_server.load::<Mesh>("model.fbx#Mesh0");
 let material = asset_server.load::<StandardMaterial>("model.fbx#Material0");
 ```

--- a/examples/dump_fbx.rs
+++ b/examples/dump_fbx.rs
@@ -1,0 +1,81 @@
+//! Headless inspection of a loaded FBX asset.
+//!
+//! Loads the file through the full Bevy asset pipeline (no window) and prints
+//! what the loader produced:
+//!
+//! ```sh
+//! cargo run --example dump_fbx -- my_model.fbx
+//! ```
+
+use bevy::asset::{AssetPlugin, LoadState};
+use bevy::image::Image;
+use bevy::mesh::skinning::SkinnedMeshInverseBindposes;
+use bevy::prelude::*;
+use bevy::world_serialization::WorldAsset;
+use bevy_ufbx::{Fbx, FbxPlugin};
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "cube.fbx".to_string());
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, AssetPlugin::default()))
+        .init_asset::<Mesh>()
+        .init_asset::<StandardMaterial>()
+        .init_asset::<Image>()
+        .init_asset::<WorldAsset>()
+        .init_asset::<SkinnedMeshInverseBindposes>()
+        .add_plugins(FbxPlugin);
+
+    let handle: Handle<Fbx> = app.world().resource::<AssetServer>().load(path.clone());
+
+    loop {
+        app.update();
+        match app.world().resource::<AssetServer>().load_state(&handle) {
+            LoadState::Loaded => break,
+            LoadState::Failed(err) => {
+                eprintln!("FAILED to load '{path}': {err}");
+                std::process::exit(1);
+            }
+            _ => std::thread::sleep(std::time::Duration::from_millis(10)),
+        }
+    }
+
+    let world = app.world();
+    let fbx_assets = world.resource::<Assets<Fbx>>();
+    let fbx = fbx_assets
+        .get(&handle)
+        .expect("Fbx asset missing after successful load");
+
+    println!("loaded '{path}'");
+    println!("  scenes:    {}", fbx.scenes.len());
+    println!("  meshes:    {}", fbx.meshes.len());
+    println!("  materials: {}", fbx.materials.len());
+    println!("  nodes:     {}", fbx.nodes.len());
+    println!("  skins:     {}", fbx.skins.len());
+    for name in fbx.named_skins.keys() {
+        println!("  skin: {name}");
+    }
+
+    for (i, (_, mesh)) in world.resource::<Assets<Mesh>>().iter().enumerate() {
+        let verts = mesh.count_vertices();
+        let joints = mesh
+            .attribute(Mesh::ATTRIBUTE_JOINT_INDEX)
+            .map(|a| a.len())
+            .unwrap_or(0);
+        println!("  Mesh{i}: {verts} vertices, {joints} joint indices");
+    }
+
+    for (i, (_, mat)) in world
+        .resource::<Assets<StandardMaterial>>()
+        .iter()
+        .enumerate()
+    {
+        println!(
+            "  Material{i}: base_color={:?} textured={}",
+            mat.base_color,
+            mat.base_color_texture.is_some()
+        );
+    }
+}

--- a/examples/load_fbx.rs
+++ b/examples/load_fbx.rs
@@ -12,6 +12,7 @@
 //! `load_with_settings` section at the bottom of `setup`.
 
 use bevy::prelude::*;
+use bevy::world_serialization::WorldAssetRoot;
 use bevy_ufbx::{Fbx, FbxLoaderSettings, FbxPlugin};
 
 fn main() {
@@ -44,7 +45,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         DirectionalLight {
             illuminance: 10_000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_rotation(Quat::from_euler(
@@ -68,7 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // --- Default loading ---
     let scene = asset_server.load(format!("{path}#Scene0"));
-    commands.spawn((SceneRoot(scene), Spinning));
+    commands.spawn((WorldAssetRoot(scene), Spinning));
 
     // --- Custom settings (uncomment to use instead) ---
     // let fbx = asset_server.load_with_settings::<Fbx, FbxLoaderSettings>(

--- a/src/label.rs
+++ b/src/label.rs
@@ -4,7 +4,7 @@ use bevy::asset::AssetPath;
 /// Labels that can be used to load part of an FBX asset
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FbxAssetLabel {
-    /// `Scene{}`: FBX Scene as a Bevy [`Scene`](bevy::scene::Scene)
+    /// `Scene{}`: FBX Scene as a Bevy [`WorldAsset`](bevy::world_serialization::WorldAsset)
     Scene(usize),
     /// `Mesh{}`: FBX Mesh as a Bevy [`Mesh`](bevy::render::mesh::Mesh)
     Mesh(usize),

--- a/src/material.rs
+++ b/src/material.rs
@@ -7,7 +7,7 @@ use crate::utils::convert_texture_uv_transform;
 use bevy::asset::{Handle, LoadContext};
 use bevy::pbr::StandardMaterial;
 use bevy::prelude::*;
-use bevy::render::alpha::AlphaMode;
+use bevy::material::AlphaMode;
 use std::collections::HashMap;
 
 /// Process all materials from the FBX scene.

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -7,7 +7,7 @@ use crate::utils::convert_matrix;
 use bevy::asset::{Handle, LoadContext};
 use bevy::pbr::StandardMaterial;
 use bevy::prelude::*;
-use bevy::scene::Scene;
+use bevy::world_serialization::WorldAsset;
 use std::collections::HashMap;
 
 /// Build the final scene with all entities.
@@ -20,7 +20,7 @@ pub fn build_scene(
     mesh_material_info: &[Vec<String>],
     settings: &FbxLoaderSettings,
     load_context: &mut LoadContext,
-) -> Result<Handle<Scene>, FbxError> {
+) -> Result<Handle<WorldAsset>, FbxError> {
     let mut world = World::new();
 
     // Create default material if needed
@@ -67,7 +67,7 @@ pub fn build_scene(
     }
 
     let scene_handle =
-        load_context.add_labeled_asset(FbxAssetLabel::Scene(0).to_string(), Scene::new(world));
+        load_context.add_labeled_asset(FbxAssetLabel::Scene(0).to_string(), WorldAsset::new(world));
 
     Ok(scene_handle)
 }
@@ -91,7 +91,7 @@ pub fn spawn_lights(scene: &ufbx::Scene, world: &mut World) {
                                 light.color.z as f32,
                             ),
                             illuminance: light.intensity as f32 * 10000.0,
-                            shadows_enabled: light.cast_shadows,
+                            shadow_maps_enabled: light.cast_shadows,
                             ..Default::default()
                         },
                         transform,
@@ -108,7 +108,7 @@ pub fn spawn_lights(scene: &ufbx::Scene, world: &mut World) {
                                 light.color.z as f32,
                             ),
                             intensity: light.intensity as f32 * 1000.0,
-                            shadows_enabled: light.cast_shadows,
+                            shadow_maps_enabled: light.cast_shadows,
                             ..Default::default()
                         },
                         transform,
@@ -125,7 +125,7 @@ pub fn spawn_lights(scene: &ufbx::Scene, world: &mut World) {
                                 light.color.z as f32,
                             ),
                             intensity: light.intensity as f32 * 1000.0,
-                            shadows_enabled: light.cast_shadows,
+                            shadow_maps_enabled: light.cast_shadows,
                             inner_angle: light.inner_angle as f32,
                             outer_angle: light.outer_angle as f32,
                             ..Default::default()

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ use bevy::math::Affine2;
 use bevy::pbr::StandardMaterial;
 use bevy::prelude::*;
 use bevy::mesh::skinning::SkinnedMeshInverseBindposes;
-use bevy::scene::Scene;
+use bevy::world_serialization::WorldAsset;
 use std::collections::HashMap;
 
 // ============================================================================
@@ -178,8 +178,8 @@ pub enum FbxInterpolation {
 /// Representation of a loaded FBX file.
 #[derive(Asset, Debug, TypePath)]
 pub struct Fbx {
-    pub scenes: Vec<Handle<Scene>>,
-    pub named_scenes: HashMap<Box<str>, Handle<Scene>>,
+    pub scenes: Vec<Handle<WorldAsset>>,
+    pub named_scenes: HashMap<Box<str>, Handle<WorldAsset>>,
     pub meshes: Vec<Handle<Mesh>>,
     pub named_meshes: HashMap<Box<str>, Handle<Mesh>>,
     pub materials: Vec<Handle<StandardMaterial>>,
@@ -188,7 +188,7 @@ pub struct Fbx {
     pub named_nodes: HashMap<Box<str>, Handle<FbxNode>>,
     pub skins: Vec<Handle<FbxSkin>>,
     pub named_skins: HashMap<Box<str>, Handle<FbxSkin>>,
-    pub default_scene: Option<Handle<Scene>>,
+    pub default_scene: Option<Handle<WorldAsset>>,
     pub axis_system: FbxAxisSystem,
     pub unit_scale: f32,
     pub metadata: FbxMeta,


### PR DESCRIPTION
## Migrate to Bevy 0.19

Updates the loader to build against Bevy `0.19`.

### Changes
- **Scenes V2:** Bevy 0.19 replaced the world-carrying `Scene` asset with a trait, so scenes are now stored as `WorldAsset` (from the new `bevy_world_serialization` crate) and spawned via `WorldAssetRoot` instead of `SceneRoot`. This mirrors how `bevy_gltf` 0.19 handles it.
- `Scene::new(world)` → `WorldAsset::new(world)`; added the `bevy_world_serialization` feature to the `bevy` dependency.
- Light field `shadows_enabled` → `shadow_maps_enabled` on directional/point/spot lights.
- `AlphaMode` moved from `bevy::render::alpha` to `bevy::material`.
- Bumped crate version to `0.19.0`; updated the README compatibility table and code snippets.
- Added `examples/dump_fbx.rs`, a headless loader inspector (loads an FBX through the full asset pipeline with no window and prints scene/mesh/material/skin counts) — handy for CI-style validation. Happy to drop this from the PR if you'd rather keep it out.

### Validation
`cargo check --all-targets` is clean and all existing tests pass on 0.19. Also validated against a rigged character FBX (ACC-rigged model): meshes, materials, embedded `.fbm` textures, and skinning all load correctly through the 0.19 pipeline.

### Notes
- One pre-existing rough edge surfaced during testing: Bevy's own `ImageLoader` panics on embedded `.fbm` textures that have no file extension (it can't sniff the format). This isn't a regression from this PR — models whose `.fbm` textures carry proper extensions load fine. Might be worth a separate follow-up.
